### PR TITLE
Feature/if title has bracket

### DIFF
--- a/lib/mdstyle_linker.rb
+++ b/lib/mdstyle_linker.rb
@@ -14,6 +14,11 @@ module MdstyleLinker
       # res.readはプレーンなstringで返ってくる
       # EOFがめんどくさいので最初に弾いちゃう
       title = res.read.gsub(/[\r\n\t]/, '').match(/<head.*>.*<title>(.+?)<\/title>.*<\/head>/)[1]
+
+      # titleのブラケットをエスケープする
+      # ちなみにrubyではputsとかでバックスラッシュを出力するとそのまま表示されてしまうらしい
+      table = {"[" => "\\[", "]" => "\\]"}
+      title.gsub!(/[\[\]]/, table)
       "[#{title}](#{url})"
     rescue StandardError => e
       puts e

--- a/spec/mdstyle_linker_spec.rb
+++ b/spec/mdstyle_linker_spec.rb
@@ -1,9 +1,15 @@
+require "mdstyle_linker"
+
 RSpec.describe MdstyleLinker do
   it "has a version number" do
     expect(MdstyleLinker::VERSION).not_to be nil
   end
 
-  it "does something useful" do
-    expect(false).to eq(true)
+  context "Normal processing" do
+    it "can generate [title](url) by URL" do
+      url = "https://en.wikipedia.org/wiki/Ruby_(programming_language)"
+      ans = "[Ruby (programming language) - Wikipedia](https://en.wikipedia.org/wiki/Ruby_(programming_language))"
+      expect(MdstyleLinker.mdstyle(url)).to eq ans
+    end
   end
 end

--- a/spec/mdstyle_linker_spec.rb
+++ b/spec/mdstyle_linker_spec.rb
@@ -11,5 +11,10 @@ RSpec.describe MdstyleLinker do
       ans = "[Ruby (programming language) - Wikipedia](https://en.wikipedia.org/wiki/Ruby_(programming_language))"
       expect(MdstyleLinker.mdstyle(url)).to eq ans
     end
+    it "case of title has bracket" do
+      url = "https://github.com/halllllll/mdstyle_linker"
+      ans = "[GitHub - halllllll/mdstyle_linker: generate markdown style link from URL (e.g. \\\[title\\\](url))](https://github.com/halllllll/mdstyle_linker)"
+      expect(MdstyleLinker.mdstyle(url)).to eq ans
+    end
   end
 end


### PR DESCRIPTION
タイトルにブラケットが含まれる場合に閉じ括弧で`[title](url)`のmarkdownのリンク構文ができちゃうので、ブラケットをエスケープした